### PR TITLE
Removed unused permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -65,7 +65,6 @@
         ,"geolocation"
         ,"<all_urls>"
         ,"notifications"
-        ,"contextMenus"
     ],
     "short_name": "__MSG_extensionShortName__"
 }


### PR DESCRIPTION
This permission have to be removed since the chrome.contextMenus API is not used.